### PR TITLE
Fix to work with latest MooX::Options

### DIFF
--- a/lib/Message/Passing.pm
+++ b/lib/Message/Passing.pm
@@ -11,9 +11,10 @@ use 5.8.4;
 our $VERSION = '0.103';
 $VERSION = eval $VERSION;
 
-sub new_with_options {
+around 'parse_options' => sub {
+    my $orig = shift;
     my $class = shift;
-    my %args = $class->parse_options(@_);
+    my %args = $orig->($class, @_);
 
     if (my $conf = $args{configfile}) {
         my $cfg = $class->get_config_from_file($conf);
@@ -23,8 +24,10 @@ sub new_with_options {
             }
         }
     }
-    $class->new(%args);
-}
+    
+    return %args;
+};
+
 
 with
     CLIComponent( name => 'input' ),


### PR DESCRIPTION
If we define a `new_with_options` method, MooX::Options will skip most of its magic.

See https://github.com/celogeek/MooX-Options/commit/7a8e7e32659d366f65bb173eefa4f713fce4b177
