### PR TITLE
Skip dot files

### DIFF
--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -9,4 +9,4 @@
 ^pm_to_blib
 blib/
 .git/
-
+^\.


### PR DESCRIPTION
So that .travis.yml isn't bundled in the distribution

(fixes https://rt.cpan.org/Public/Bug/Display.html?id=99893)