### PR TITLE
Attempt to support tags in ToLogstash

### DIFF
--- a/lib/Message/Passing/Filter/ToLogstash.pm
+++ b/lib/Message/Passing/Filter/ToLogstash.pm
@@ -46,6 +46,10 @@ sub filter {
     if (exists($message->{'@fields'}{epochtime})) {
         $message->{'@timestamp'} = DateTime->from_epoch(epoch => delete($message->{'@fields'}{epochtime})) . ''
     }
+    if (exists($message->{'@fields'}->{'tags'})) {
+        # we move tags here, to keep the loop simpler
+        $message->{'@tags'} = delete $message->{'@fields'}->{tags};
+    }
     foreach my $k (keys %map) {
         my $v = $map{$k};
         $v = [ '', $v ] if !ref $v;
@@ -54,6 +58,10 @@ sub filter {
         if (exists($message->{'@fields'}{$k}) && !exists($message->{$field})) {
             $message->{$field} = $prefix . delete $message->{'@fields'}{$k};
         }
+    }
+    if ($message->{'@tags'} and ref $message->{'@tags'} ne ref []) {
+        # We have something in tags that isn't a ref, lets wrap it
+        $message->{'@tags'} = [ $message->{'@tags'} ];
     }
     $message->{'@tags'} ||= $self->default_tags;
     $message->{'@tags'} = [ uniq @{ $message->{'@tags'} }, @{ $self->add_tags } ];

--- a/t/filter_tologstash.t
+++ b/t/filter_tologstash.t
@@ -42,6 +42,16 @@ my @data = (
         { date => '2012-09-03T21:08:54', message => 'foo',},
         { '@fields' => {}, '@tags' => [], '@message' => 'foo', '@timestamp' => '2012-09-03T21:08:54' },
     ],
+    [
+        'one tag',
+        { tags => 'foo', message => 'foo' },
+        { '@fields' => {}, '@tags' => [ 'foo' ], '@message' => 'foo' },
+    ],
+    [
+        'two tags',
+        { tags => ['foo', 'bar'], message => 'foo' },
+        { '@fields' => {}, '@tags' => [ 'foo', 'bar' ], '@message' => 'foo' },
+    ],
 );
 
 foreach my $datum (@data) {


### PR DESCRIPTION
There was some code to support tags in ToLogstash, but it seemed incomplete, in
that there was no moving tags from `@fields` after moving everything to `@fields`.

Move them back out of fields, so the adding tags and default tags work as
intended. Add tests for passing bot a string in tags, and an array ref.

We handle the moving outside of the %MAP, because the loop stringifies, and
making it not stringify complicated it more than the extra if clause (in my
opinion).